### PR TITLE
[BUGFIX] Do not list system low level users for non admins.

### DIFF
--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -9,6 +9,8 @@ namespace Serfhos\MyUserManagement\Domain\Repository;
 class BackendUserRepository extends \TYPO3\CMS\Beuser\Domain\Repository\BackendUserRepository
 {
 
+    protected static $systemUsers = array('_cli_lowlevel', '_cli_scheduler');
+
     /**
      * @var array
      */
@@ -29,5 +31,41 @@ class BackendUserRepository extends \TYPO3\CMS\Beuser\Domain\Repository\BackendU
             $query->equals('disable', false)
         )));
         return $query->execute();
+    }
+
+    /**
+     * Find Backend Users matching to Demand object properties
+     *
+     * @param \TYPO3\CMS\Beuser\Domain\Model\Demand $demand
+     * @return \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult<\TYPO3\CMS\Beuser\Domain\Model\BackendUser>
+     */
+    public function findDemanded(\TYPO3\CMS\Beuser\Domain\Model\Demand $demand)
+    {
+        /** @var \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult $queryResult */
+        $objects = parent::findDemanded($demand);
+
+        // Do not list system low level users for non admins.
+        if ($this->getBackendUserAuthentication()->isAdmin() === false && $objects instanceof \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult) {
+            /** @var TYPO3\CMS\Extbase\Persistence\Generic\Query $query */
+            $query = $objects->getQuery();
+            $query->matching(
+                $query->logicalAnd(
+                    $query->getConstraint(),
+                    $query->logicalNot(
+                        $query->in('username', static::$systemUsers)
+                    )
+                )
+            );
+            return $query->execute();
+        }
+        return $objects;
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUserAuthentication()
+    {
+        return $GLOBALS['BE_USER'];
     }
 }


### PR DESCRIPTION
Hi. I think it is better not to list system low level users (_cli_lowlevel and _cli_scheduler) for non admins.