### PR TITLE
[FEATURE] Restrict users of a group only to view, select and modify u…

### DIFF
--- a/Classes/Controller/BackendUserController.php
+++ b/Classes/Controller/BackendUserController.php
@@ -24,6 +24,19 @@ class BackendUserController extends \TYPO3\CMS\Beuser\Controller\BackendUserCont
     protected $backendUserRepository;
 
     /**
+     * @var \Serfhos\MyUserManagement\Domain\Repository\BackendUserGroupRepository
+     */
+    protected $backendUserGroupRepository;
+
+    /**
+     * @param \Serfhos\MyUserManagement\Domain\Repository\BackendUserGroupRepository $backendUserGroupRepository
+     */
+    public function injectBackendUserGroupRepository(\Serfhos\MyUserManagement\Domain\Repository\BackendUserGroupRepository $backendUserGroupRepository)
+    {
+        $this->backendUserGroupRepository = $backendUserGroupRepository;
+    }
+
+    /**
      * Set up the view template configuration correctly for BackendTemplateView
      *
      * @param ViewInterface $view

--- a/Classes/Controller/BackendUserGroupController.php
+++ b/Classes/Controller/BackendUserGroupController.php
@@ -13,6 +13,19 @@ class BackendUserGroupController extends \TYPO3\CMS\Beuser\Controller\BackendUse
 {
 
     /**
+     * @var \Serfhos\MyUserManagement\Domain\Repository\BackendUserGroupRepository
+     */
+    protected $backendUserGroupRepository;
+
+    /**
+     * @param \Serfhos\MyUserManagement\Domain\Repository\BackendUserGroupRepository $backendUserGroupRepository
+     */
+    public function injectBackendUserGroupRepository(\Serfhos\MyUserManagement\Domain\Repository\BackendUserGroupRepository $backendUserGroupRepository)
+    {
+        $this->backendUserGroupRepository = $backendUserGroupRepository;
+    }
+
+    /**
      * Set up the view template configuration correctly for BackendTemplateView
      *
      * @param ViewInterface $view

--- a/Classes/Domain/Model/Dto/RestrictBackendUserGroupPermission.php
+++ b/Classes/Domain/Model/Dto/RestrictBackendUserGroupPermission.php
@@ -1,0 +1,86 @@
+<?php
+namespace Serfhos\MyUserManagement\Domain\Model\Dto;
+
+/*                                                                        *
+ * This script is part of the TYPO3 project - inspiring people to share!  *
+ *                                                                        *
+ * TYPO3 is free software; you can redistribute it and/or modify it under *
+ * the terms of the GNU General Public License version 3 as published by  *
+ * the Free Software Foundation.                                          *
+ *                                                                        *
+ * This script is distributed in the hope that it will be useful, but     *
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHAN-    *
+ * TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General      *
+ * Public License for more details.                                       *
+ *                                                                        */
+
+/**
+ * RestrictBackendUserGroupPermission
+ */
+class RestrictBackendUserGroupPermission implements \ArrayAccess
+{
+    const KEY = 'tx_myusermanagement_restrictbackendusergroup';
+
+    protected static $locallang = 'EXT:my_user_management/Resources/Private/Language/locallang.xlf';
+    protected $array = null;
+
+    protected function initialize()
+    {
+        $this->array = [];
+        $beGroups = $this->getDatabasConnection()->exec_SELECTgetRows('uid,title,description', 'be_groups', 'deleted=0 AND hidden=0', '', 'title');
+        if (!empty($beGroups)) {
+            $this->array['header'] = 'LLL:' . static::$locallang . ':restrictbackendusergroup.header';
+            $this->array['items'] = [];
+            foreach ($beGroups as $beGroup) {
+                $this->array['items'][$beGroup['uid']] = [
+                    $beGroup['title'],
+                    'EXT:core/Resources/Public/Icons/T3Icons/status/status-user-group-backend.svg',
+                    $beGroup['description'],
+                ];
+            }
+        }
+    }
+
+    /**
+     * @return TYPO3\CMS\Core\Database\DatabaseConnection
+     */
+    protected function getDatabasConnection()
+    {
+        return $GLOBALS['TYPO3_DB'];
+    }
+
+    // {{{ ArrayAccess
+    final public function offsetSet($offset, $value)
+    {
+        if ($this->array === null) {
+            $this->initialize();
+        }
+        if (is_null($offset)) {
+            $this->array[] = $value;
+        } else {
+            $this->array[$offset] = $value;
+        }
+    }
+    final public function offsetExists($offset)
+    {
+        if ($this->array === null) {
+            $this->initialize();
+        }
+        return isset($this->array[$offset]);
+    }
+    final public function offsetUnset($offset)
+    {
+        if ($this->array === null) {
+            $this->initialize();
+        }
+        unset($this->array[$offset]);
+    }
+    final public function offsetGet($offset)
+    {
+        if ($this->array === null) {
+            $this->initialize();
+        }
+        return isset($this->array[$offset]) ? $this->array[$offset] : null;
+    }
+    // }}}
+}

--- a/Classes/Domain/Repository/BackendUserGroupRepository.php
+++ b/Classes/Domain/Repository/BackendUserGroupRepository.php
@@ -1,0 +1,57 @@
+<?php
+namespace Serfhos\MyUserManagement\Domain\Repository;
+
+/**
+ * Repository: BackendUserGroup
+ *
+ * @package Serfhos\MyUserManagement\Domain\Repository
+ */
+class BackendUserGroupRepository extends \TYPO3\CMS\Beuser\Domain\Repository\BackendUserGroupRepository
+{
+    /**
+     * @var Serfhos\MyUserManagement\Service\RestrictBackendUserGroupService
+     * @inject
+     */
+    protected $restrictBackendUserGroupService;
+
+    public function findAll()
+    {
+        $objects = parent::findAll();
+
+        if ($this->getBackendUserAuthentication()->isAdmin() === false) {
+            $objects = $this->restrictBackendUserGroupService->getRestrictedBackendUserGroups();
+        }
+
+        return $objects;
+    }
+
+    /**
+     * Find records by uids
+     *
+     * @param  array  $uids
+     * @return TYPO3\CMS\Extbase\Persistence\QueryResultInterface
+     */
+    public function findByUids(array $uids)
+    {
+        /** @var TYPO3\CMS\Extbase\Persistence\Generic\Query $query */
+        $query = $this->createQuery();
+
+        $query->matching(
+            $query->in('uid', $uids)
+        );
+        // $GLOBALS['TYPO3_DB']->store_lastBuiltQuery = 1;
+        // $a = $query->execute();
+        // \TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump($a);
+        // \TYPO3\CMS\Extbase\Utility\DebuggerUtility::var_dump($GLOBALS['TYPO3_DB']->debug_lastBuiltQuery);
+
+        return $query->execute();
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUserAuthentication()
+    {
+        return $GLOBALS['BE_USER'];
+    }
+}

--- a/Classes/Domain/Repository/BackendUserRepository.php
+++ b/Classes/Domain/Repository/BackendUserRepository.php
@@ -9,6 +9,15 @@ namespace Serfhos\MyUserManagement\Domain\Repository;
 class BackendUserRepository extends \TYPO3\CMS\Beuser\Domain\Repository\BackendUserRepository
 {
 
+    protected static $systemUsers = array('_cli_lowlevel', '_cli_scheduler');
+
+
+    /**
+     * @var Serfhos\MyUserManagement\Service\RestrictBackendUserGroupService
+     * @inject
+     */
+    protected $restrictBackendUserGroupService;
+
     /**
      * @var array
      */
@@ -29,5 +38,53 @@ class BackendUserRepository extends \TYPO3\CMS\Beuser\Domain\Repository\BackendU
             $query->equals('disable', false)
         )));
         return $query->execute();
+    }
+
+    /**
+     * Find Backend Users matching to Demand object properties
+     *
+     * @param \TYPO3\CMS\Beuser\Domain\Model\Demand $demand
+     * @return \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult<\TYPO3\CMS\Beuser\Domain\Model\BackendUser>
+     */
+    public function findDemanded(\TYPO3\CMS\Beuser\Domain\Model\Demand $demand)
+    {
+        /** @var \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult $queryResult */
+        $objects = parent::findDemanded($demand);
+
+        /** @var TYPO3\CMS\Extbase\Persistence\Generic\Query $query */
+        $query = $objects->getQuery();
+
+        // Do not list system low level users for non admins.
+        if ($this->getBackendUserAuthentication()->isAdmin() === false && $objects instanceof \TYPO3\CMS\Extbase\Persistence\Generic\QueryResult) {
+            $query->matching(
+                $query->logicalAnd(
+                    $query->getConstraint(),
+                    $query->logicalNot(
+                        $query->in('username', static::$systemUsers)
+                    )
+                )
+            );
+        }
+
+        // Limit listed users to choosen groups from custom permission.
+        $groups = $this->restrictBackendUserGroupService->getRestrictedBackendUserGroups();
+        if (count($groups)) {
+            $query->matching(
+                $query->logicalAnd(
+                    $query->getConstraint(),
+                    $query->in('usergroup', $groups)
+                )
+            );
+        }
+
+        return $query->execute();
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUserAuthentication()
+    {
+        return $GLOBALS['BE_USER'];
     }
 }

--- a/Classes/Hooks/ItemsProcFunc.php
+++ b/Classes/Hooks/ItemsProcFunc.php
@@ -1,0 +1,50 @@
+<?php
+namespace Serfhos\MyUserManagement\Hooks;
+
+use Serfhos\MyUserManagement\Domain\Model\BackendUser;
+use Serfhos\MyUserManagement\Domain\Model\BackendUserGroup;
+use Serfhos\MyUserManagement\Service\RestrictBackendUserGroupService;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+
+/**
+ * ItemsProcFunc
+ *
+ * @package Serfhos\MyUserManagement\Hooks
+ */
+class ItemsProcFunc implements \TYPO3\CMS\Core\SingletonInterface
+{
+    /**
+     * @var Serfhos\MyUserManagement\Service\RestrictBackendUserGroupService
+     */
+    protected $restrictBackendUserGroupService;
+
+    public function __construct()
+    {
+        $this->restrictBackendUserGroupService = GeneralUtility::makeInstance(ObjectManager::class)->get(RestrictBackendUserGroupService::class);
+    }
+
+    /**
+     * Overwrite items if any group is choosen in custom permissions.
+     *
+     * @param  array                                                   &$params [description]
+     * @param  \TYPO3\CMS\Backend\Form\FormDataProvider\TcaSelectItems &$pObj   [description]
+     * @return void
+     */
+    public function getRestrictedBackendUserGroups(array &$params, \TYPO3\CMS\Backend\Form\FormDataProvider\TcaSelectItems &$pObj)
+    {
+        $groups = $this->restrictBackendUserGroupService->getRestrictedBackendUserGroups();
+        if (count($groups)) {
+            $items = [];
+            foreach ($groups as $group) {
+                $items[] = [
+                    $group->getTitle(),
+                    $group->getUid(),
+                    'status-user-group-backend',
+                ];
+            }
+            $params['items'] = $items;
+        }
+    }
+}

--- a/Classes/Service/RestrictBackendUserGroupService.php
+++ b/Classes/Service/RestrictBackendUserGroupService.php
@@ -1,0 +1,55 @@
+<?php
+namespace Serfhos\MyUserManagement\Service;
+
+use Serfhos\MyUserManagement\Domain\Model\BackendUser;
+use Serfhos\MyUserManagement\Domain\Model\BackendUserGroup;
+use Serfhos\MyUserManagement\Domain\Model\Dto\RestrictBackendUserGroupPermission;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Service: Permission
+ *
+ * @package Serfhos\MyUserManagement\Service
+ */
+class RestrictBackendUserGroupService implements \TYPO3\CMS\Core\SingletonInterface
+{
+
+    /**
+     * @var \Serfhos\MyUserManagement\Domain\Repository\BackendUserGroupRepository
+     * @inject
+     */
+    protected $backendUserGroupRepository;
+
+    /**
+     * Return groups selected in custom permissons.
+     *
+     * @return TYPO3\CMS\Extbase\Persistence\QueryResultInterface
+     */
+    public function getRestrictedBackendUserGroups()
+    {
+        $uids = [];
+
+        /** @var string $customPermissions */
+        $customPermissions = $this->getBackendUserAuthentication()->groupData['custom_options'];
+
+        // Read custom permissions and add selected groups to the storage.
+        foreach (GeneralUtility::trimExplode(',', $customPermissions, true) as $optionValue) {
+            if (strpos($optionValue, RestrictBackendUserGroupPermission::KEY) === 0) {
+                $uids[] = (int) substr($optionValue, strlen(RestrictBackendUserGroupPermission::KEY) + 1);
+            }
+        }
+        if (empty($uids)) {
+            return $this->backendUserGroupRepository->findAll();
+        }
+        return $this->backendUserGroupRepository->findByUids($uids);
+    }
+
+    /**
+     * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+     */
+    protected function getBackendUserAuthentication()
+    {
+        return $GLOBALS['BE_USER'];
+    }
+}

--- a/Configuration/TCA/Overrides/BackendGroup.php
+++ b/Configuration/TCA/Overrides/BackendGroup.php
@@ -14,3 +14,5 @@ foreach ($GLOBALS['TCA']['be_groups']['columns'] as $key => &$configuration) {
         $configuration['exclude'] = 1;
     }
 }
+
+$GLOBALS['TCA']['be_groups']['columns']['subgroup']['config']['itemsProcFunc'] = 'Serfhos\\MyUserManagement\\Hooks\\ItemsProcFunc->getRestrictedBackendUserGroups';

--- a/Configuration/TCA/Overrides/BackendUser.php
+++ b/Configuration/TCA/Overrides/BackendUser.php
@@ -22,3 +22,5 @@ foreach ($GLOBALS['TCA']['be_users']['columns'] as $key => &$configuration) {
             break;
     }
 }
+
+$GLOBALS['TCA']['be_users']['columns']['usergroup']['config']['itemsProcFunc'] = 'Serfhos\\MyUserManagement\\Hooks\\ItemsProcFunc->getRestrictedBackendUserGroups';

--- a/Configuration/TypoScript/setup.ts
+++ b/Configuration/TypoScript/setup.ts
@@ -52,3 +52,6 @@ module.tx_myusermanagement {
         dummy = foo
     }
 }
+
+// TYPO3 throws an error if not set on extbase config.
+config.tx_extbase.persistence.classes.Serfhos\MyUserManagement\Domain\Model\BackendUserGroup < module.tx_myusermanagement.persistence.classes.Serfhos\MyUserManagement\Domain\Model\BackendUserGroup

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -219,6 +219,9 @@
             <trans-unit id="backendLoginHistory_all_records">
                 <source>All known records</source>
             </trans-unit>
+            <trans-unit id="restrictbackendusergroup.header">
+                <source>My Backend User Management: Restrict user group listing.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -74,4 +74,6 @@ if (TYPO3_MODE === 'BE') {
             'labels' => 'LLL:EXT:' . $_EXTKEY . '/Resources/Private/Language/Backend/LoginHistory.xlf',
         )
     );
+
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions'][\Serfhos\MyUserManagement\Domain\Model\Dto\RestrictBackendUserGroupPermission::KEY] = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\Serfhos\MyUserManagement\Domain\Model\Dto\RestrictBackendUserGroupPermission::class);
 }


### PR DESCRIPTION
[FEATURE] Restrict users of a group only to view, select and modify users of certain groups selected in custom permission settings for backend users groups.

Thist commit may conflicts with the bugfix request. Anyway this commit includes also the bugfix.

The idea of this request is to restrict the set of groups for a backend user. With this feature it is possible that users can create other users only of certain groups.